### PR TITLE
i18n: add Chinese localization support

### DIFF
--- a/src/game/locales/enemy.yaml
+++ b/src/game/locales/enemy.yaml
@@ -12,6 +12,7 @@ enemy.path_visibility.pre_wave_visible:
     nl: "Tussen de golven"
     tr: "Dalgalar arasında"
     pl: "Między falami"
+    zh: "回合之间"
 enemy.path_visibility.always_visible:
     en: "Always"
     ru: "Всегда"
@@ -24,6 +25,7 @@ enemy.path_visibility.always_visible:
     nl: "Altijd"
     tr: "Her zaman"
     pl: "Zawsze"
+    zh: "总是"
 enemy.path_visibility.never_visible:
     en: "Never"
     ru: "Никогда"
@@ -36,3 +38,4 @@ enemy.path_visibility.never_visible:
     nl: "Nooit"
     tr: "Asla"
     pl: "Nigdy"
+    zh: "从不"

--- a/src/game/locales/error.yaml
+++ b/src/game/locales/error.yaml
@@ -12,3 +12,4 @@ error.level_select.file_reading_error.title:
     nl: "Bestandsleesfout"
     tr: "Dosya okuma hatası"
     pl: "Błąd odczytu pliku"
+    zh: "文件读取错误"

--- a/src/game/locales/levels.yaml
+++ b/src/game/locales/levels.yaml
@@ -12,6 +12,7 @@ level.example:
     nl: "Voorbeeld"
     tr: "Örnek"
     pl: "Przykład"
+    zh: "样例"
 level.ring:
     en: "Ring"
     ru: "Кольцо"
@@ -24,6 +25,7 @@ level.ring:
     nl: "Ring"
     tr: "Halka"
     pl: "Pierścień"
+    zh: "环路"
 level.zigzag:
     en: "Zigzag"
     ru: "Зигзаг"
@@ -36,6 +38,7 @@ level.zigzag:
     nl: "Zigzag"
     tr: "Zikzak"
     pl: "Zygzak"
+    zh: "蜿蜒小路"
 level.coastal_highway:
     en: "Coastal Highway"
     ru: "Прибрежное шоссе"
@@ -48,6 +51,7 @@ level.coastal_highway:
     nl: "Kustweg"
     tr: "Sahil otoyolu"
     pl: "Nadmorska autostrada"
+    zh: "滨海公路"
 level.error:
     en: "Error"
     ru: "Ошибка"
@@ -60,3 +64,4 @@ level.error:
     nl: "Fout"
     tr: "Hata"
     pl: "Błąd"
+    zh: "错误"

--- a/src/game/locales/soldier.yaml
+++ b/src/game/locales/soldier.yaml
@@ -12,6 +12,7 @@ soldier.variant.soldier:
     nl: "Soldaat"
     tr: "Asker"
     pl: "Żołnierz"
+    zh: "士兵"
 soldier.variant.rocket_launcher:
     en: "Rocket launcher"
     ru: "Ракетница"
@@ -24,6 +25,7 @@ soldier.variant.rocket_launcher:
     nl: "Raketwerper"
     tr: "Roketatar"
     pl: "Wyrzutnia rakiet"
+    zh: "火箭炮"
 soldier.variant.sniper:
     en: "Sniper"
     ru: "Снайпер"
@@ -36,6 +38,7 @@ soldier.variant.sniper:
     nl: "Scherpschutter"
     tr: "Keskin nişancı"
     pl: "Snajper"
+    zh: "狙击手"
 
 soldier.info.name:
     en: "Name: %{name}"
@@ -49,6 +52,7 @@ soldier.info.name:
     nl: "Naam: %{name}"
     tr: "Adı: %{name}"
     pl: "Nazwa: %{name}"
+    zh: "名称: %{name}"
 soldier.info.level:
     en: "Level: %{level}/%{max_level}"
     ru: "Уровень: %{level}/%{max_level}"
@@ -61,6 +65,7 @@ soldier.info.level:
     nl: "Niveau: %{level}/%{max_level}"
     tr: "Seviye: %{level}/%{max_level}"
     pl: "Poziom: %{level}/%{max_level}"
+    zh: "等级: %{name}"
 soldier.info.max_level:
     en: "Max level: %{max_level}"
     ru: "Максимальный уровень: %{max_level}"
@@ -73,6 +78,7 @@ soldier.info.max_level:
     nl: "Maximaal niveau: %{max_level}"
     tr: "Maksimum seviye: %{max_level}"
     pl: "Maksymalny poziom: %{max_level}"
+    zh: "最高等级: %{max_level}"
 soldier.info.damage:
     en: "Damage: %{damage}"
     ru: "Урон: %{damage}"
@@ -85,6 +91,7 @@ soldier.info.damage:
     nl: "Schade: %{damage}"
     tr: "Hasar: %{damage}"
     pl: "Obrażenia: %{damage}"
+    zh: "伤害: %{damage}"
 soldier.info.fire_radius:
     en: "Fire radius: %{fire_radius}"
     ru: "Радиус стрельбы: %{fire_radius}"
@@ -97,6 +104,7 @@ soldier.info.fire_radius:
     nl: "Vuurradius: %{fire_radius}"
     tr: "Atış menzili: %{fire_radius}"
     pl: "Zasięg strzału: %{fire_radius}"
+    zh: "开火半径: %{fire_radius}"
 soldier.info.blast_radius:
     en: "Blast radius: %{blast_radius}"
     ru: "Радиус взрыва: %{blast_radius}"
@@ -109,6 +117,7 @@ soldier.info.blast_radius:
     nl: "Explosieradius: %{blast_radius}"
     tr: "Patlama yarıçapı: %{blast_radius}"
     pl: "Promień wybuchu: %{blast_radius}"
+    zh: "爆炸半径: %{blast_radius}"
 soldier.info.fire_rate:
     en: "Fire rate: %{fire_rate}/s"
     ru: "Скорострельность: %{fire_rate}/с"
@@ -121,6 +130,7 @@ soldier.info.fire_rate:
     nl: "Vuursnelheid: %{fire_rate}/s"
     tr: "Atış hızı: %{fire_rate}/s"
     pl: "Szybkostrzelność: %{fire_rate}/s"
+    zh: "发射频率: %{fire_rate}/s"
 
 soldier.target_priority.first:
     en: "Attack the first"
@@ -134,6 +144,7 @@ soldier.target_priority.first:
     nl: "Val de eerste aan"
     tr: "İlk hedefe saldır"
     pl: "Atakuj pierwszego"
+    zh: "位置最靠前"
 soldier.target_priority.last:
     en: "Attack the last"
     ru: "Атаковать последнюю"
@@ -146,6 +157,7 @@ soldier.target_priority.last:
     nl: "Val de laatste aan"
     tr: "Son hedefe saldır"
     pl: "Atakuj ostatniego"
+    zh: "位置最靠后"
 soldier.target_priority.strongest:
     en: "Attack the strongest"
     ru: "Атаковать самую стойкую"
@@ -158,6 +170,7 @@ soldier.target_priority.strongest:
     nl: "Val de sterkste aan"
     tr: "En güçlüye saldır"
     pl: "Atakuj najsilniejszego"
+    zh: "剩余血量最高"
 soldier.target_priority.weakest:
     en: "Attack the weakest"
     ru: "Атаковать самую слабую"
@@ -170,6 +183,7 @@ soldier.target_priority.weakest:
     nl: "Val de zwakste aan"
     tr: "En zayıfa saldır"
     pl: "Atakuj najsłabszego"
+    zh: "剩余血量最低"
 soldier.target_priority.nearest:
     en: "Attack the nearest"
     ru: "Атаковать ближайшую"
@@ -182,6 +196,7 @@ soldier.target_priority.nearest:
     nl: "Val de dichtstbijzijnde aan"
     tr: "En yakına saldır"
     pl: "Atakuj najbliższego"
+    zh: "距离最小"
 
 soldier.placement.with_confirmation:
     en: "Place with confirmation"
@@ -195,6 +210,7 @@ soldier.placement.with_confirmation:
     nl: "Plaatsen met bevestiging"
     tr: "Onaylı yerleştir"
     pl: "Umieścić z potwierdzeniem"
+    zh: "部署前确认"
 soldier.placement.without_confirmation:
     en: "Place without confirmation"
     ru: "Размещать без подтверждения"
@@ -207,3 +223,4 @@ soldier.placement.without_confirmation:
     nl: "Plaatsen zonder bevestiging"
     tr: "Onaysız yerleştir"
     pl: "Umieścić bez potwierdzenia"
+    zh: "部署并确认"

--- a/src/game/locales/ui.yaml
+++ b/src/game/locales/ui.yaml
@@ -12,6 +12,7 @@ ui.version:
     nl: "Versie: %{version}"
     tr: "Sürüm: %{version}"
     pl: "Wersja: %{version}"
+    zh: "版本: %{version}"
 
 ui.menu.game_title:
     en: "Pico TD"
@@ -25,6 +26,7 @@ ui.menu.game_title:
     nl: "Pico TD"
     tr: "Pico TD"
     pl: "Pico TD"
+    zh: "Pico TD"
 ui.menu.start_game:
     en: "Start game"
     ru: "Начать игру"
@@ -37,6 +39,7 @@ ui.menu.start_game:
     nl: "Spel starten"
     tr: "Oyunu başlat"
     pl: "Rozpocznij grę"
+    zh: "开始游戏"
 ui.menu.settings:
     en: "Settings"
     ru: "Настройки"
@@ -49,6 +52,7 @@ ui.menu.settings:
     nl: "Instellingen"
     tr: "Ayarlar"
     pl: "Ustawienia"
+    zh: "设置"
 ui.menu.exit_game:
     en: "Exit game"
     ru: "Выйти из игры"
@@ -61,6 +65,7 @@ ui.menu.exit_game:
     nl: "Spel afsluiten"
     tr: "Oyundan çık"
     pl: "Wyjdź z gry"
+    zh: "退出游戏"
 
 ui.settings.title:
     en: "Settings"
@@ -74,6 +79,7 @@ ui.settings.title:
     nl: "Instellingen"
     tr: "Ayarlar"
     pl: "Ustawienia"
+    zh: "设置"
 ui.settings.change_locale:
     en: "Change language"
     ru: "Сменить язык"
@@ -86,6 +92,7 @@ ui.settings.change_locale:
     nl: "Taal wijzigen"
     tr: "Dili değiştir"
     pl: "Zmień język"
+    zh: "设置语言"
 ui.settings.current_language:
     en: "English"
     ru: "Русский"
@@ -98,6 +105,7 @@ ui.settings.current_language:
     nl: "Nederlands"
     tr: "Türkçe"
     pl: "Polski"
+    zh: "简体中文"
 ui.settings.music_volume:
     en: "Music volume"
     ru: "Громкость музыки"
@@ -110,6 +118,7 @@ ui.settings.music_volume:
     nl: "Muziekvolume"
     tr: "Müzik sesi"
     pl: "Głośność muzyki"
+    zh: "音乐音量"
 ui.settings.sfx_volume:
     en: "SFX volume"
     ru: "Громкость звуков"
@@ -122,6 +131,7 @@ ui.settings.sfx_volume:
     nl: "Effectvolume"
     tr: "Efekt sesi"
     pl: "Głośność efektu"
+    zh: "音效音量"
 ui.settings.reset_progress:
     en: "Reset Progress"
     ru: "Сбросить прогресс"
@@ -134,6 +144,7 @@ ui.settings.reset_progress:
     nl: "Voortgang resetten"
     tr: "İlerlemeyi sıfırla"
     pl: "Resetuj postęp"
+    zh: "重置进度"
 
 ui.level_select.title:
     en: "Select level"
@@ -147,6 +158,7 @@ ui.level_select.title:
     nl: "Selecteer niveau"
     tr: "Seviye seç"
     pl: "Wybierz poziom"
+    zh: "选择关卡"
 ui.level_select.upload_level:
     en: "Upload level"
     ru: "Загрузить уровень"
@@ -159,6 +171,7 @@ ui.level_select.upload_level:
     nl: "Upload niveau"
     tr: "Seviye yükle"
     pl: "Prześlij poziom"
+    zh: "上传关卡"
 
 ui.in_game.health:
     en: "%{health}"
@@ -172,6 +185,7 @@ ui.in_game.health:
     nl: "%{health}"
     tr: "%{health}"
     pl: "%{health}"
+    zh: "%{health}"
 ui.in_game.money:
     en: "%{money}"
     ru: "%{money}"
@@ -184,6 +198,7 @@ ui.in_game.money:
     nl: "%{money}"
     tr: "%{money}"
     pl: "%{money}"
+    zh: "%{money}"
 ui.in_game.wave:
     en: "Wave %{current}/%{total}"
     ru: "Волна %{current}/%{total}"
@@ -196,6 +211,7 @@ ui.in_game.wave:
     nl: "Golf %{current}/%{total}"
     tr: "Dalga %{current}/%{total}"
     pl: "Fala %{current}/%{total}"
+    zh: "回合 %{current}/%{total}"
 ui.in_game.game_speed:
     en: "Speed: x%{speed}"
     ru: "Скорость: x%{speed}"
@@ -208,6 +224,7 @@ ui.in_game.game_speed:
     nl: "Snelheid: x%{speed}"
     tr: "Hız: x%{speed}"
     pl: "Prędkość: x%{speed}"
+    zh: "速度: x%{speed}"
 ui.in_game.pause:
     en: "Pause"
     ru: "Пауза"
@@ -220,6 +237,7 @@ ui.in_game.pause:
     nl: "Pauze"
     tr: "Duraklat"
     pl: "Pauza"
+    zh: "暂停"
 ui.in_game.next_wave:
     en: "Next wave"
     ru: "Следующая волна"
@@ -232,6 +250,7 @@ ui.in_game.next_wave:
     nl: "Volgende golf"
     tr: "Sonraki dalga"
     pl: "Następna fala"
+    zh: "下一回合"
 
 ui.soldier_select.title:
     en: "Select soldier"
@@ -245,6 +264,7 @@ ui.soldier_select.title:
     nl: "Selecteer soldaat"
     tr: "Asker seç"
     pl: "Wybierz żołnierza"
+    zh: "选择士兵"
 ui.soldier_select.price:
     en: "%{price}$"
     ru: "%{price}$"
@@ -257,6 +277,7 @@ ui.soldier_select.price:
     nl: "%{price}$"
     tr: "%{price}$"
     pl: "%{price}$"
+    zh: "%{price}$"
 
 ui.soldier_placement_confirmation.confirm:
     en: "Confirm"
@@ -270,6 +291,7 @@ ui.soldier_placement_confirmation.confirm:
     nl: "Bevestigen"
     tr: "Onayla"
     pl: "Potwierdzenie"
+    zh: "确定"
 ui.soldier_placement_confirmation.cancel:
     en: "Cancel"
     ru: "Отмена"
@@ -282,6 +304,7 @@ ui.soldier_placement_confirmation.cancel:
     nl: "Annuleren"
     tr: "İptal"
     pl: "Anuluj"
+    zh: "取消"
 
 ui.soldier_info.title:
     en: "Soldier info"
@@ -295,6 +318,7 @@ ui.soldier_info.title:
     nl: "Soldaat info"
     tr: "Asker bilgisi"
     pl: "Informacje o żołnierzu"
+    zh: "士兵状态"
 ui.soldier_info.target_priority:
     en: "Target priority"
     ru: "Приоритет выбора цели"
@@ -307,6 +331,7 @@ ui.soldier_info.target_priority:
     nl: "Doelprioriteit"
     tr: "Hedef önceliği"
     pl: "Priorytet celu"
+    zh: "优先目标"
 ui.soldier_info.upgrade_soldier:
     en: "Upgrade %{price}$"
     ru: "Улучшить %{price}$"
@@ -319,6 +344,7 @@ ui.soldier_info.upgrade_soldier:
     nl: "Upgraden %{price}$"
     tr: "Yükselt %{price}$"
     pl: "Ulepsz %{price}$"
+    zh: "升级 %{price}$"
 ui.soldier_info.sell_soldier:
     en: "Sell %{sell_price}$"
     ru: "Продать %{sell_price}$"
@@ -331,6 +357,7 @@ ui.soldier_info.sell_soldier:
     nl: "Verkopen %{sell_price}$"
     tr: "Sat %{sell_price}$"
     pl: "Sprzedaj %{sell_price}$"
+    zh: "出售 %{sell_price}$"
 
 ui.pause.title:
     en: "Pause"
@@ -344,6 +371,7 @@ ui.pause.title:
     nl: "Pauze"
     tr: "Duraklat"
     pl: "Pauza"
+    zh: "暂停"
 ui.pause.enemy_path_visibility:
     en: "Show enemy paths"
     ru: "Отображать пути врагов"
@@ -356,6 +384,7 @@ ui.pause.enemy_path_visibility:
     nl: "Vijandelijke paden weergeven"
     tr: "Düşman yollarını göster"
     pl: "Wyświetlanie ścieżek wroga"
+    zh: "显示进攻路线"
 ui.pause.resume_game:
     en: "Resume game"
     ru: "Продолжить игру"
@@ -368,6 +397,7 @@ ui.pause.resume_game:
     nl: "Hervat spel"
     tr: "Devam et"
     pl: "Wznów grę"
+    zh: "恢复游戏"
 ui.pause.restart_level:
     en: "Restart level"
     ru: "Рестарт уровня"
@@ -380,6 +410,7 @@ ui.pause.restart_level:
     nl: "Herstart niveau"
     tr: "Bölümü tekrar başlat"
     pl: "Zrestartuj poziom"
+    zh: "重启关卡"
 ui.pause.back_to_menu:
     en: "Back to menu"
     ru: "Вернуться в меню"
@@ -392,6 +423,7 @@ ui.pause.back_to_menu:
     nl: "Terug naar menu"
     tr: "Menüye dön"
     pl: "Powrót do menu"
+    zh: "返回菜单"
 
 ui.game_over.player_win:
     en: "You win!"
@@ -405,6 +437,7 @@ ui.game_over.player_win:
     nl: "Je hebt gewonnen!"
     tr: "Kazandın!"
     pl: "Wygrałeś!"
+    zh: "你赢了!"
 ui.game_over.player_lose:
     en: "You lose!"
     ru: "Вы проиграли!"
@@ -417,6 +450,7 @@ ui.game_over.player_lose:
     nl: "Je hebt verloren!"
     tr: "Kaybettin!"
     pl: "Przegrałeś!"
+    zh: "你输了!"
 ui.game_over.waves_survived:
     en: "Waves survived: %{current_wave}/%{total_waves}"
     ru: "Волн отражено: %{current_wave}/%{total_waves}"
@@ -429,6 +463,7 @@ ui.game_over.waves_survived:
     nl: "Overleefde golven: %{current_wave}/%{total_waves}"
     tr: "Hayatta kalınan dalgalar: %{current_wave}/%{total_waves}"
     pl: "Przetrwane fale: %{current_wave}/%{total_waves}"
+    zh: "存活回合: %{current_wave}/%{total_waves}"
 ui.game_over.retry_level:
     en: "Retry level"
     ru: "Повторить уровень"
@@ -441,6 +476,7 @@ ui.game_over.retry_level:
     nl: "Herhaal niveau"
     tr: "Bölümü tekrar et"
     pl: "Powtórz poziom"
+    zh: "重试关卡"
 ui.game_over.back_to_menu:
     en: "Back to menu"
     ru: "Вернуться в меню"
@@ -453,3 +489,4 @@ ui.game_over.back_to_menu:
     nl: "Terug naar menu"
     tr: "Menüye dön"
     pl: "Powrót do menu"
+    zh: "返回菜单"

--- a/src/game/ui/i18n.rs
+++ b/src/game/ui/i18n.rs
@@ -16,6 +16,7 @@ pub enum Locale {
     Nl,
     Tr,
     Pl,
+    Zh,
 }
 
 impl Locale {
@@ -32,6 +33,7 @@ impl Locale {
             Locale::Nl => "nl",
             Locale::Tr => "tr",
             Locale::Pl => "pl",
+            Locale::Zh => "zh",
         }
         .to_string()
     }
@@ -48,6 +50,7 @@ impl Locale {
             "nl" => Locale::Nl,
             "tr" => Locale::Tr,
             "pl" => Locale::Pl,
+            "zh" => Locale::Zh,
             _ => Locale::En,
         }
     }

--- a/src/game/ui/views/settings.rs
+++ b/src/game/ui/views/settings.rs
@@ -133,6 +133,7 @@ fn init_ui(
                                             Locale::Nl,
                                             Locale::Tr,
                                             Locale::Pl,
+                                            Locale::Zh,
                                         ]
                                         .iter()
                                         .map(|locale| {


### PR DESCRIPTION
This adds locale selection & translation
To make Chinese characters rendering work, we need also specify a Chinese pixel style font (for example, fusion-pixel/ark-pixel)